### PR TITLE
Kp/ll encapsulation

### DIFF
--- a/02-linked-lists/02-linked-lists-implementation.md
+++ b/02-linked-lists/02-linked-lists-implementation.md
@@ -174,7 +174,7 @@ Encapsulation allows data structures to be designed _abstractly_, meaning the im
 * type: code-snippet
 * language: python3.6
 * id: a9c61442-b23f-44c3-8b05-eae600e286dc
-* title: implement get_firstg
+* title: implement get_first
 * points: 1
 * 
 ##### !question

--- a/02-linked-lists/02-linked-lists-implementation.md
+++ b/02-linked-lists/02-linked-lists-implementation.md
@@ -162,7 +162,7 @@ def add_first(self, value):
 
 When designing data structures, our design will typically group together multiple pieces of data as well as methods that operate on our data structure. For example with our LinkedList class above, we group together the `head` attribute with our operations `add_first`, `get_first`, `add_last`, `get_last`, and `get_at_index`.
 
- Bundling together multiple pieces of data and methods that operate on that data is called _encapsulation_. In fact, every time we create a class, we are encapsulating data.  
+Bundling together multiple pieces of data and methods that operate on that data is called _encapsulation_. In fact, every time we create a class, we are encapsulating data.  
 
 Encapsulation allows data structures to be designed _abstractly_, meaning the implementation of the data structure is hidden. This allows the internal implementation of the data structure to change without affecting user functionality. As a result, the designer could switch a linked list into an array list without the user needing to know. They could also transition from a singly linked list into a doubly linked list without impacting users. 
 

--- a/02-linked-lists/02-linked-lists-implementation.md
+++ b/02-linked-lists/02-linked-lists-implementation.md
@@ -1,6 +1,9 @@
 # Object Oriented Design of a Linked List
 
-### Node Class
+## Overview
+The Node class encapsulates each individual 
+
+## Node Class
 
 The Node class encapsulates each individual element of the linked list. It is comprised of an attribute that stores data and an attribute that stores the next node in the chain. It provides an interface for the LinkedList class we will create to handle the data and link nodes together.
 
@@ -75,7 +78,7 @@ You might also consider passing in default values for `next` and `prev`.
 
 <!-- ======================= END CHALLENGE ======================= -->
 
-### LinkedList Class
+## LinkedList Class
 
 The LinkedList class has a single attribute `head` which stores a reference to the first node in the list. Our constructor initializes `head` to `None` so that when a new LinkedList is initialized, we are creating an empty list.  
 

--- a/02-linked-lists/02-linked-lists-implementation.md
+++ b/02-linked-lists/02-linked-lists-implementation.md
@@ -149,9 +149,11 @@ def add_first(self, value):
 
 ### Encapsulation
 
-When designing a data structure like a linked list, we typically want our design to include not just our linked nodes but also methods that operate on our linked list, such as methods to add nodes, delete nodes, or get the length of the linked list. Bundling together multiple pieces of data and methods that operate on that data is called __encapsulation__, and you may already be familiar with it in the form of classes. 
+When designing data structures, our design will typically group together multiple pieces of data as well as methods that operate on our data structure. For example with our LinkedList class above, we group together the `head` attribute with our operations `add_first`, `get_first`, `add_last`, `get_last`, and `get_at_index`.
 
-Encapsulation also enables us to design our data structure as __abstract__, meaning that the implementation of the data structure is hidden. This allows the internal implementation of the data structure to change without affecting user functionality. As a result, the designer could switch a linked list into an array list without the user needing to know. They could also transition from a singly linked list into a doubly linked list without impacting users. 
+ Bundling together multiple pieces of data and methods that operate on that data is called _encapsulation_. In fact, every time we create a class, we are encapsulating data.  
+
+Encapsulation allows data structures to be designed _abstractly_, meaning the implementation of the data structure is hidden. This allows the internal implementation of the data structure to change without affecting user functionality. As a result, the designer could switch a linked list into an array list without the user needing to know. They could also transition from a singly linked list into a doubly linked list without impacting users. 
 
 <!-- >>>>>>>>>>>>>>>>>>>>>> BEGIN CHALLENGE >>>>>>>>>>>>>>>>>>>>>> -->
 <!-- Replace everything in square brackets [] and remove brackets  -->

--- a/02-linked-lists/02-linked-lists-implementation.md
+++ b/02-linked-lists/02-linked-lists-implementation.md
@@ -5,6 +5,17 @@ In Python, linked lists are not a built-in data type. So how might we represent 
 
 Linked lists are a collection of nodes. A node is also a data structure that is not built in to Python. Thus, in order to represent a linked list, we will first want to define a Node class that represents a single element in a linked list. We can then define a LinkedList class that represents an ordered collection of individual Node objects. 
 
+<!-- available callout types: info, success, warning, danger, secondary, star  -->
+### !callout-info
+
+## Linked Lists in Other Languages
+
+Many languages, such as [Java](https://docs.oracle.com/javase/7/docs/api/java/util/LinkedList.html), offer standard implementations of linked lists. Packages such as [CPython's `llist`](https://pythonhosted.org/llist/) can also be used to avoid needing to implement your own linked list in Python.
+
+Still, knowing the basics of how linked lists are implemented can help us better understand how and when to use them!
+
+### !end-callout
+
 ## Node Class
 
 The Node class encapsulates each individual element of the linked list. It is comprised of an attribute that stores data and an attribute that stores the next node in the chain. It provides an interface for the LinkedList class we will create to handle the data and link nodes together.
@@ -163,7 +174,7 @@ Encapsulation allows data structures to be designed _abstractly_, meaning the im
 * type: code-snippet
 * language: python3.6
 * id: a9c61442-b23f-44c3-8b05-eae600e286dc
-* title: implement get_first
+* title: implement get_firstg
 * points: 1
 * 
 ##### !question

--- a/02-linked-lists/02-linked-lists-implementation.md
+++ b/02-linked-lists/02-linked-lists-implementation.md
@@ -1,11 +1,5 @@
 # Object Oriented Design of a Linked List
 
-### Encapsulation
-
-When designing a data structure like a linked list, we typically want our design to include not just our linked nodes but also methods that operate on our linked list, such as methods to add nodes, delete nodes, or get the length of the linked list. Bundling together multiple pieces of data and methods that operate on that data is called __encapsulation__, and you may already be familiar with it in the form of classes. 
-
-Encapsulation also enables us to design our data structure as __abstract__, meaning that the implementation of the data structure is hidden. This allows the internal implementation of the data structure to change without affecting user functionality. As a result, the designer could switch a linked list into an array list without the user needing to know. They could also transition from a singly linked list into a doubly linked list without impacting users. 
-
 ### Node Class
 
 The Node class encapsulates each individual element of the linked list. It is comprised of an attribute that stores data and an attribute that stores the next node in the chain. It provides an interface for the LinkedList class we will create to handle the data and link nodes together.
@@ -147,6 +141,12 @@ def add_first(self, value):
 ```
 
 <!--TODO: Add challenge question adding node for a doubly linked list-->
+
+### Encapsulation
+
+When designing a data structure like a linked list, we typically want our design to include not just our linked nodes but also methods that operate on our linked list, such as methods to add nodes, delete nodes, or get the length of the linked list. Bundling together multiple pieces of data and methods that operate on that data is called __encapsulation__, and you may already be familiar with it in the form of classes. 
+
+Encapsulation also enables us to design our data structure as __abstract__, meaning that the implementation of the data structure is hidden. This allows the internal implementation of the data structure to change without affecting user functionality. As a result, the designer could switch a linked list into an array list without the user needing to know. They could also transition from a singly linked list into a doubly linked list without impacting users. 
 
 <!-- >>>>>>>>>>>>>>>>>>>>>> BEGIN CHALLENGE >>>>>>>>>>>>>>>>>>>>>> -->
 <!-- Replace everything in square brackets [] and remove brackets  -->

--- a/02-linked-lists/02-linked-lists-implementation.md
+++ b/02-linked-lists/02-linked-lists-implementation.md
@@ -1,7 +1,9 @@
 # Object Oriented Design of a Linked List
 
 ## Overview
-The Node class encapsulates each individual 
+In Python, linked lists are not a built-in data type. So how might we represent linked lists? Classes provide a mechanism for us to define our own linked list data type. 
+
+Linked lists are a collection of nodes. A node is also a data structure that is not built in to Python. Thus, in order to represent a linked list, we will first want to define a Node class that represents a single element in a linked list. We can then define a LinkedList class that represents an ordered collection of individual Node objects. 
 
 ## Node Class
 


### PR DESCRIPTION
Before: 
- Encapsulation information was used to introduce Linked List OOP Implementation lesson

Now:
- Encapsulation is introduced after `Node` and `LinkedList` classes are introduced
- Lesson begins with reminder about uses of classes and overview of how to use OOP to represent LLs 

Review Focus:
- Lesson flow
- Clarity of explanations
- Are there any redundancies in new lesson content? Could anything be removed?
