### PR TITLE
Update about TAA for c18

### DIFF
--- a/00-about-thursdays-at-ada/about-thursdays-at-ada.md
+++ b/00-about-thursdays-at-ada/about-thursdays-at-ada.md
@@ -3,15 +3,15 @@
 In Computer Science fundamentals students learn the following concepts and data structures:
 
 
-- [Algorithmic Approaches](../01-algorithms/01-algorithms.md) such as Divide & Conquer, Dynamic 
+- [Algorithmic Approaches](../01-algorithms/01-algorithms.md)
 - [Linked Lists](../02-linked-lists/01-linked-lists.md)
 - [Binary Search Trees](../03-Binary-Search-Trees/01-Ordered-Collections-Of-Data.md)
 - [Graphs: BFS & DFS](../04-graphs/01-graphs.md)
-- [Graphs: Dijkstra](../05-dijkstras/01-graphs-review.md)Programming & Greedy Algorithms
+- [Graphs: Dijkstra](../05-dijkstras/01-graphs-review.md)
 
 ### Reverse Classroom
 
-CS Fundamentals is taught in a [flipped-classroom](https://omerad.msu.edu/index.php?option=com_content&view=article&id=162:what-why-and-how-to-implement-a-flipped-classroom-model&catid=27:teaching) style. Students are assigned a week prior to review a markdown lesson with accompanying video lesson and slides. In class students are expected to ask questions, review concepts, and work on exercises in groups. Students are also given time to engage in a mock interview with a peer.
+CS Fundamentals is taught in a [flipped-classroom](https://omerad.msu.edu/index.php?option=com_content&view=article&id=162:what-why-and-how-to-implement-a-flipped-classroom-model&catid=27:teaching) style. Students are provided with a Learn topic to review two weeks prior to a live review session. In class students are expected to ask questions, review concepts, and work on exercises in groups. 
 
 ### CS Fun Recorded Sessions
 
@@ -28,28 +28,28 @@ All the CS Fundamentals and Career Services online sessions are recorded in Pano
 - [Thursdays at Ada Guide](https://drive.google.com/file/d/1Vz_NIgcPUqJlR9d1ZYUW8y3lJNVL_Xfl/view?usp=sharing)
 - [Thursdays at Ada Office Hours Guide](https://docs.google.com/document/d/12gi9oNXoXWvpJPANPbKE_KAvCJ9dwVNSkXmht5H0M84/edit?usp=sharing)
 - [Career Development Post Session Document](https://docs.google.com/document/d/1smwDoWvg1GUZjkxj4-CNSIDZpsbvwzBPHHXj5BQn748/edit?usp=sharing)
-- [CS Fundamentals Self Study Guide](https://docs.google.com/document/d/1Q5hpP5k4aNA3rTZB7_FkY8ZcxKldU_kkF21ssF5gMFE/edit?usp=sharing)
-- [Request Instructor Feedback on your Project Submission](https://forms.gle/8Y73jxau5T9kR8Q37)
+- [Your Study Plan Template](https://docs.google.com/document/d/1uCUKu9sZLUSbxsUVobnf8d2EaudXIQxqFpSRhhYE2jU/edit?usp=sharing)
+- [Submit an Alteration to Your Study Plan](https://docs.google.com/forms/d/e/1FAIpQLSeBxKIJUhkQ9li3ZOmsSnqlQ38xnBhLEYO8Bnh2CkJkf8i3Ww/viewform?usp=sf_link)
 
-#### Section A
-- [Section A Thursdays at Ada Overview Calendar](https://drive.google.com/file/d/1iQuNpFJ73xROlf-PZevYyWR_x1ZFImbk/view?usp=sharing)
-- [Section A CS Fundamentals Detailed Class Schedule](https://docs.google.com/document/d/1YHIPQZ50EqcFOiQKt3G76znzv-xwXEwqYzEMkEtjm8s/edit?usp=sharing)
+#### Ligers
+- [Ligers Thursdays at Ada Overview Calendar](https://calendar.google.com/calendar/u/0?cid=Y18wZmVlNmQxZWFhNzM4YWVlNzM5YTRkZjZmNmRjN2YzNzFmNmExMDkxYWFjMzlkODBhM2YzMjkyNDBlN2I4ZDBlQGdyb3VwLmNhbGVuZGFyLmdvb2dsZS5jb20)
+- [Ligers CS Fundamentals Detailed Class Schedule](https://docs.google.com/document/d/14UwD9Er-pqmEgcEh1efBihnR-dgeSWhPE0K0N8KU1Wo/edit?usp=share_link)
+- [Ligers Personal Study Plan Guide](https://docs.google.com/document/d/19RsoW-SDkUapg0CQuTbCLKaUHuPGDFs6jh85QsjSTJs/edit?usp=sharing)
 
-#### Section B
-- [Section B Thursdays at Ada Overview Calendar](https://drive.google.com/file/d/1dInNdZve_Kb5dicLH32zeB0S6ZcrLj20/view?usp=sharing)
-- [ Section B CS Fundamentals Detailed Class Schedule](https://docs.google.com/document/d/18Rbl1scPfK3G0r25aQupYiAdDKrtHbBj5SyZlhDSFhw/edit?usp=sharing)
+#### Tigons
+- [Tigons Thursdays at Ada Overview Calendar](https://calendar.google.com/calendar/u/0?cid=Y19jYmZjN2VkMGRkMjkxY2M3MGNjMGM1NzljYzkxNzY4MzZhMTQ0MWJlYTk1MWRlMTc4ODc3NGE5ZDA0OTI0MTBmQGdyb3VwLmNhbGVuZGFyLmdvb2dsZS5jb20)
+- [ Tigons CS Fundamentals Detailed Class Schedule](https://docs.google.com/document/d/1qQ9FzZ-w0Tep3KENv3knBzXXKmIhCX2il8362ixGWvk/edit?usp=share_link)
+- [Tigons Personal Study Plan Guide](https://docs.google.com/document/d/1pwa85WrRYpqs6rVNPSqOB6QZo-BH4tQcItQ_k99gSkc/edit?usp=sharing)
 
 
 #### Office Hours
-- [Seattle Office Hours](https://calendar.google.com/calendar/embed?src=c_cm98vq3aobh8vjgsvjofbojs40%40group.calendar.google.com&ctz=America%2FLos_Angeles)
-- [Digital Office Hours](https://calendar.google.com/calendar/embed?src=c_uaq8jpkddnnq12uof9733jhpn0%40group.calendar.google.com&ctz=America%2FLos_Angeles)
-
+- [Office Hours Calendar](https://calendar.google.com/calendar/u/0?cid=Y183NGY4Zjk4NDM1MWQ1NzEyZDIxOWVlMGFkOTBmN2EyMjBkYjcxN2RlOTkzODZlZGZlNTZkNDgwNWYxODUxYmVjQGdyb3VwLmNhbGVuZGFyLmdvb2dsZS5jb20)
 
 #### Classroom Links
-- Career Development Sessions are hosted via Zoom Webinar. Links to each session's will be posted in your section's Slack channel.
-- CS Fundamentals sessions will be held in the [CS Fundamentals Zoom Room](https://adadev-org.zoom.us/j/7753306872)
+- Career Development Sessions and Mock Interviews are hosted in the [Career Services Zoom Room](http://careerservices.adadev.org)
+- CS Fundamentals sessions will be held in the [CS Fundamentals Zoom Room](http://cs-fun.adadev.org)
 
 
 #### Study Hall Zoom
-- The [thursdays.adadev.org](https://thursdays.adadev.org) is available for intern use as a study hall. 
+- The [thursdays.adadev.org](https://thursdays.adadev.org) is available for intern use as a study hall and community space. 
 - Host Key: 471379

--- a/00-about-thursdays-at-ada/norms.md
+++ b/00-about-thursdays-at-ada/norms.md
@@ -3,7 +3,7 @@
 * **Attendance at Thursdays at Ada is optional for graduation** from the program. 
   * We expect interns to be choose to engage with live Thursdays at Ada content as is most helpful to their learning needs.
 * CS Fundamentals assignments are a required part of your continuing education and graduation requirements. 
-  * **You need to complete 80% of problem sets for CS Fundamentals**. 
+  * **You need to complete 80% (4/5) of problem sets for CS Fundamentals**. 
   * **You need to complete 100% of Interview Practice Questions for CS Fundamentals**.
   * **You need to complete 5 peer-to-peer mock interviews for CS Fundamentals**.
   * New topics and problem sets are released at least two weeks before they are due

--- a/00-about-thursdays-at-ada/norms.md
+++ b/00-about-thursdays-at-ada/norms.md
@@ -1,19 +1,15 @@
 # Thursdays at Ada Norms
 
-* **Attendance at Thursdays at Ada is required for graduation** from the program. 
-  * We expect interns to be present for the entirety of the four hour Thursdays at Ada sessions. 
-  * We understand that sometimes things come up and external circumstances may cause you to miss part of or the entirety of a session. If you need to miss a CS Fundamentals or Career Services session, please send an email to [absent_internship@adadevelopersacademy.org
-  ](mailto:absent_internship@adadevelopersacademy.org
-  ) in advance when possible.
-  * Up to two excused absences are permitted throughout the course of Thursdays at Ada. This is across both Career Development and CS Fundamentals sessions.
+* **Attendance at Thursdays at Ada is optional for graduation** from the program. 
+  * We expect interns to be choose to engage with live Thursdays at Ada content as is most helpful to their learning needs.
 * CS Fundamentals assignments are a required part of your continuing education and graduation requirements. 
-  * **You need to complete 80% of all assigned work for CS Fundamentals**. 
-  * New topics and problem sets are released two weeks before they are due
+  * **You need to complete 80% of problem sets for CS Fundamentals**. 
+  * **You need to complete 100% of Interview Practice Questions for CS Fundamentals**.
+  * **You need to complete 5 peer-to-peer mock interviews for CS Fundamentals**.
+  * New topics and problem sets are released at least two weeks before they are due
   * New projects are released four weeks before they are due
   * Please contact your instructors and make use of the TAs for support.
-  * Contact Courtney Chen at [courtney.chen@adadevelopersacademy.org](mailto:courtney.chen@adadevelopersacademy.org), your Student Success Coach for Thursdays at Ada to set up a Learning Plan
-  * Contact your assigned Career Services Manager for Internship support
-* There will be some required submissions for the Career Services lessons.
+  * Contact the Career Services Managers for Internship support
 * Career Development facilitators and speakers are volunteers who are excited to share their expertise with you. 
   * Please keep your video on when possible during Thursdays at Ada sessions, with the understanding that sometimes video on will not feel comfortable, and that is okay.
-  * Please try to stay as engaged as possible (answering questions, responding in the chat, participating in interactive breakout sessions or sharing out your thoughts if you are comfortable).
+  * Please stay as engaged as possible (answering questions, responding in the chat, participating in interactive breakout sessions or sharing out your thoughts if you are comfortable).

--- a/00-about-thursdays-at-ada/norms.md
+++ b/00-about-thursdays-at-ada/norms.md
@@ -4,7 +4,7 @@
   * We expect interns to be choose to engage with live Thursdays at Ada content as is most helpful to their learning needs.
 * CS Fundamentals assignments are a required part of your continuing education and graduation requirements. 
   * **You need to complete 80% (4/5) of problem sets for CS Fundamentals**. 
-  * **You need to complete 100% of Interview Practice Questions for CS Fundamentals**.
+  * **You need to complete 100% (5/5) of Interview Practice Questions for CS Fundamentals**.
   * **You need to complete 5 peer-to-peer mock interviews for CS Fundamentals**.
   * New topics and problem sets are released at least two weeks before they are due
   * New projects are released four weeks before they are due

--- a/00-about-thursdays-at-ada/norms.md
+++ b/00-about-thursdays-at-ada/norms.md
@@ -1,7 +1,7 @@
 # Thursdays at Ada Norms
 
 * **Attendance at Thursdays at Ada is optional for graduation** from the program. 
-  * We expect interns to be choose to engage with live Thursdays at Ada content as is most helpful to their learning needs.
+  * We expect interns to choose to engage with live Thursdays at Ada content as is most helpful to their learning needs.
 * CS Fundamentals assignments are a required part of your continuing education and graduation requirements. 
   * **You need to complete 80% (4/5) of problem sets for CS Fundamentals**. 
   * **You need to complete 100% (5/5) of Interview Practice Questions for CS Fundamentals**.

--- a/00-about-thursdays-at-ada/norms.md
+++ b/00-about-thursdays-at-ada/norms.md
@@ -6,8 +6,8 @@
   * **You need to complete 80% (4/5) of problem sets for CS Fundamentals**. 
   * **You need to complete 100% (5/5) of Interview Practice Questions for CS Fundamentals**.
   * **You need to complete 5 peer-to-peer mock interviews for CS Fundamentals**.
-  * New topics and problem sets are released at least two weeks before they are due
-  * New projects are released four weeks before they are due
+  * New topics and problem sets are released at least two weeks before the live session date
+  * New projects are released at least four weeks before the Plan A proposed completion date
   * Please contact your instructors and make use of the TAs for support.
   * Contact the Career Services Managers for Internship support
 * Career Development facilitators and speakers are volunteers who are excited to share their expertise with you. 

--- a/00-about-thursdays-at-ada/thursdays-at-ada.instructor.md
+++ b/00-about-thursdays-at-ada/thursdays-at-ada.instructor.md
@@ -1,3 +1,0 @@
-# Instructor Information
-
-[Attendance Link](https://forms.gle/UcN9UnhMjeKve6SB6)

--- a/00-study-plan/study-plan.checkpoint.md
+++ b/00-study-plan/study-plan.checkpoint.md
@@ -1,0 +1,78 @@
+# Study Plan Submission
+
+<!-- >>>>>>>>>>>>>>>>>>>>>> BEGIN CHALLENGE >>>>>>>>>>>>>>>>>>>>>> -->
+<!-- Replace everything in square brackets [] and remove brackets  -->
+
+### !challenge
+
+* type: multiple-choice
+* id: 4676f40f-b9b2-4704-a623-b7b2144282eb
+* title: Choose Your Path
+* points: 1
+<!-- * topics: [python, pandas] (Checkpoints only. optional the topics for analyzing points) -->
+
+##### !question
+
+Which of the study plan paths are you opting into? 
+
+##### !end-question
+
+##### !options
+
+a| Path A
+b| Path B
+c| Path C
+
+##### !end-options
+
+##### !answer
+
+a|
+b|
+c|
+
+##### !end-answer
+
+<!-- other optional sections -->
+<!-- !hint - !end-hint (markdown, hidden, students click to view) -->
+<!-- !rubric - !end-rubric (markdown, instructors can see while scoring a checkpoint) -->
+<!-- !explanation - !end-explanation (markdown, students can see after answering correctly) -->
+
+### !end-challenge
+
+<!-- ======================= END CHALLENGE ======================= -->
+
+### !challenge
+
+* type: short-answer
+* id: 133e45ba-8173-44d4-94f5-6cc7e80d8641
+* title: Study Plan
+* points: 1
+<!-- * topics: [python, pandas] (Checkpoints only, optional the topics for analyzing points) -->
+
+##### !question
+
+Please submit your study plan. If you chose Option A or B, you can copy or paste that option into your copy of the personal study plan document. 
+
+##### !end-question
+
+##### !placeholder
+
+Your Study Plan Document Link
+
+##### !end-placeholder
+
+##### !answer
+
+/.+/
+
+##### !end-answer
+
+<!-- other optional sections -->
+<!-- !hint - !end-hint (markdown, hidden, students click to view) -->
+<!-- !rubric - !end-rubric (markdown, instructors can see while scoring a checkpoint) -->
+<!-- !explanation - !end-explanation (markdown, students can see after answering correctly) -->
+
+### !end-challenge
+
+<!-- ======================= END CHALLENGE ======================= -->

--- a/00-study-plan/study-plan.md
+++ b/00-study-plan/study-plan.md
@@ -1,0 +1,37 @@
+# Thursdays at Ada Study Plan
+
+ Thursdays at Ada deadlines are flexible. We recognize that each intern will have a different internship experience where some may experience greater intensity at the beginning of internship, others may experience a heavier workload at the end of internship, and others may experience something in between.
+
+ To ensure that you recognize the scope of work we are asking you to complete and have a plan in place to complete the Thursdays at Ada course, we ask that you submit a study plan with proposed completion dates for each of the required elements.
+ 
+ See more details about each plan in your section specific study guide:
+ - [Ligers TAA Study Plan Guide](https://docs.google.com/document/d/19RsoW-SDkUapg0CQuTbCLKaUHuPGDFs6jh85QsjSTJs/edit?usp=sharing)
+ - [Tigons TAA Study Plan Guide](https://docs.google.com/document/d/1pwa85WrRYpqs6rVNPSqOB6QZo-BH4tQcItQ_k99gSkc/edit?usp=sharing)
+
+ ## Completion Options
+There a three basic paths to complete Thursdays at Ada requirements.
+
+ ### Path A
+Path A keeps pace with CS Fundamentals live sessions and will ensure you have covered all topics by the end of the third month of internship which is when many folks choose to actively begin their job search. Path A follows the pattern of learning a new CS Fundamentals topic and completing an interview practice question every two weeks. 
+
+Path A also includes ample time to review topics during the last two months of internship and practice applying them. Following Path A, we hope students will feel very solid on all Thursdays at Ada topics by graduation and will be able to independently apply them. 
+
+Accelerate students: we recommend that you choose Path A or a modified version of it as your internship is shorter. Keep in mind that you have covered Linked Lists, Binary Search Trees, and Graphs already. 
+
+ ### Path B
+Path B will allow you to dedicate most of your first two months solely to internship. We do recommend keeping up with career development sessions as they occur since preparation for career development sessions is optional and you do have the 5 hours on Thursdays set aside. We also recommend you complete one mock interview on a topic from the classroom phase early on to familiarize yourself with the format. 
+
+Path B will introduce all topics to you by the end of internship and allow you to complete all CS Fundamentals Graduation requirements with a week long buffer by the deadline. You will review each new topic and accompanying problem set by the review session. By graduation, you may feel that you need additional review of the CS Fun topics but should have a solid foundation to conduct your review independently.
+
+If you are able to read through the new topic material (without completing the problem set questions) during your first two months of internship , we would highly recommend you do so that the topics are not completely unfamiliar when you start intensive work on CS Fundamentals material.
+
+ ### Path C
+ Choose your own completion dates by filling out and submitting [your personal study plan](https://docs.google.com/document/d/1uCUKu9sZLUSbxsUVobnf8d2EaudXIQxqFpSRhhYE2jU/edit?usp=sharing)
+
+ ## Need to Change your Study Plan?
+ We expect that most interns will need to adjust their intial study plan . If you are altering any milestones we ask that you update your study plan and fill out the milestone extension form, to give the Thursdays at Ada team awareness of your progress:
+[Milestone Extension Form](https://docs.google.com/forms/d/e/1FAIpQLSeBxKIJUhkQ9li3ZOmsSnqlQ38xnBhLEYO8Bnh2CkJkf8i3Ww/viewform?usp=sf_link)
+
+ ## Final Deadline 
+ 
+ All Thursdays at Ada work must be submitted to Learn by Friday, July 21st at 11:59 PM. 

--- a/00-study-plan/study-plan.md
+++ b/00-study-plan/study-plan.md
@@ -29,7 +29,7 @@ If you are able to read through the new topic material (without completing the p
  Choose your own completion dates by filling out and submitting [your personal study plan](https://docs.google.com/document/d/1uCUKu9sZLUSbxsUVobnf8d2EaudXIQxqFpSRhhYE2jU/edit?usp=sharing)
 
  ## Need to Change your Study Plan?
- We expect that most interns will need to adjust their intial study plan . If you are altering any milestones we ask that you update your study plan and fill out the milestone extension form, to give the Thursdays at Ada team awareness of your progress:
+We expect that most interns will need to adjust their initial study plan. If you are altering any milestones we ask that you update your study plan and fill out the milestone extension form, to give the Thursdays at Ada team awareness of your progress:
 [Milestone Extension Form](https://docs.google.com/forms/d/e/1FAIpQLSeBxKIJUhkQ9li3ZOmsSnqlQ38xnBhLEYO8Bnh2CkJkf8i3Ww/viewform?usp=sf_link)
 
  ## Final Deadline 

--- a/00-study-plan/study-plan.md
+++ b/00-study-plan/study-plan.md
@@ -9,7 +9,7 @@
  - [Tigons TAA Study Plan Guide](https://docs.google.com/document/d/1pwa85WrRYpqs6rVNPSqOB6QZo-BH4tQcItQ_k99gSkc/edit?usp=sharing)
 
  ## Completion Options
-There a three basic paths to complete Thursdays at Ada requirements.
+There are three basic paths to complete Thursdays at Ada requirements.
 
  ### Path A
 Path A keeps pace with CS Fundamentals live sessions and will ensure you have covered all topics by the end of the third month of internship which is when many folks choose to actively begin their job search. Path A follows the pattern of learning a new CS Fundamentals topic and completing an interview practice question every two weeks. 

--- a/config.yaml
+++ b/config.yaml
@@ -1,16 +1,12 @@
 ---
 Standards:
   -
-    Title: Thursdays at Ada Norms
-    Description: Expectations for our sessions
+    Title: About Thursdays at Ada
+    Description: About TAA, Quick Links, Expectations for our sessions
     UID: 88fccfa1-fe50-4434-8834-6efdf422f247
     SuccessCriteria:
       - success criteria
     ContentFiles:
-      -
-        Type: Instructor
-        UID: 560d5d4e-4c3d-438b-8b52-7bbb2b209d4c
-        Path: /00-about-thursdays-at-ada/thursdays-at-ada.instructor.md
       -
         Type: Lesson
         UID: bcc6309e-3453-4aea-9b22-ef8e09c2b09e
@@ -19,6 +15,21 @@ Standards:
         Type: Lesson
         UID: 0d492a6b-c9d8-492d-910e-219ff5ea80ae
         Path: /00-about-thursdays-at-ada/about-thursdays-at-ada.md
+  -
+    Title: Your Study Plan
+    Description: Thursdays at Ada Study Plan, Submit Study Plan
+    UID: fa32f461-a844-4c4a-bd9b-d683a883fb00
+    SuccessCriteria:
+      - success criteria
+    ContentFiles:
+      -
+        Type: Lesson
+        UID: d5a97102-5509-443f-94fb-1238f3491105
+        Path: /00-study-plan/study-plan.md
+      -
+        Type: Checkpoint
+        UID: 70b97077-11e3-42fa-a5df-c54603cef704
+        Path: /00-study-plan/study-plan.checkpoint.md
   -
     Title: Algorithmic Approaches
     Description: Introduction to Algorithms, Analysis of Algorithms, Divide and Conquer, Recursion, Dynamic Programming


### PR DESCRIPTION
**Summary of Changes**
- Remove outdated requirements from About TAA
- Update links for C18
- Add submission link for study plan


Note: Some links are still outdated. Need CSM input before updating