### PR TITLE
Add activity to lesson config

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -65,6 +65,10 @@ Standards:
         Type: Lesson
         UID: e7ac6f0e-1186-4060-8be5-29e46b2fe352
         Path: /01-algorithms/07-algorithms-supplemental-resources.md
+      -
+        Type: Lesson
+        UID: 0f52cf8b-80de-4c9f-9b98-53047d37b0a2
+        Path: /01-algorithms/08-algorithms-activity.md
   -
   
     Title: Linked Lists


### PR DESCRIPTION
Not the one time I choose not to do `learn preview .` biting me in the butt 🥴 

The purpose of this PR is to add the activity file to the algorithm lesson's config. 