### PR TITLE
Updated activity links to unsolved replits

### DIFF
--- a/01-algorithms/08-algorithms-activity.md
+++ b/01-algorithms/08-algorithms-activity.md
@@ -10,9 +10,7 @@ Afterwards, you will work in groups to complete an iterative solution using Dyna
 
 Follow along in the following Replit as we livecode a recursive solution with and without Dynamic Programming: [Newman-Conway Recursively](https://replit.com/@adadev/Newman-Conway-Recursive)
 
-<!--
-* [C19 Newman-Conway Recursive Livecode Solution](#)
--->
+* [C19 Newman-Conway Recursive Livecode Solution](https://replit.com/@adadev/C19-Newman-Conway-Recursive-Solution)
 
 ### Small Group Work
 
@@ -24,7 +22,5 @@ Follow along in the following Replit as we livecode a recursive solution with an
 
 Fork the following Replit to work on in small groups: [Newman-Conway Iteratively with DP](https://replit.com/@adadev/Newman-Conway-Iterative)
 
-<!--
 Solution:
-* [C19 Small Group Solution](#)
--->
+* [C19 Small Group Solution](https://replit.com/@adadev/Newman-Conway-Iterative-Solution)

--- a/01-algorithms/08-algorithms-activity.md
+++ b/01-algorithms/08-algorithms-activity.md
@@ -10,6 +10,9 @@ Afterwards, you will work in groups to complete an iterative solution using Dyna
 
 Follow along in the following Replit as we livecode a recursive solution with and without Dynamic Programming: [Newman-Conway Recursively](https://replit.com/@adadev/Newman-Conway-Recursive)
 
+<!--
+* [C19 Newman-Conway Recursive Livecode Solution](#)
+-->
 
 ### Small Group Work
 
@@ -21,3 +24,7 @@ Follow along in the following Replit as we livecode a recursive solution with an
 
 Fork the following Replit to work on in small groups: [Newman-Conway Iteratively with DP](https://replit.com/@adadev/Newman-Conway-Iterative)
 
+<!--
+Solution:
+* [C19 Small Group Solution](#)
+-->

--- a/02-linked-lists/06-linked-list-activity.md
+++ b/02-linked-lists/06-linked-list-activity.md
@@ -2,16 +2,17 @@
 
 ## Rotate a Linked List
 
-We will go over the driving fuction in class.
+We will go over the driving function in class.
 
 Afterwards, you will work in groups to fill out the helper functions used in the driving function. Tests are added to the Replit to help you test if your helper functions work correctly.
 
 ### Class Livecode
 
 Follow along in the following Replit as we livecode the driving function in class: 
-* [Rotate Linked List Ligers Livecode](https://replit.com/@adadev/Rotate-Linked-List-Ligers-Livecode)
-* [Rotate Linked List Tigons Livecode](https://replit.com/@adadev/Rotate-Linked-List-Tigons-Livecode)
-
+* [Rotate Linked List Livecode Start](https://replit.com/@adadev/Rotate-Linked-List-Livecode-Start)
+<!--
+* [C19 Rotate Linked List Livecode Solution](#)
+-->
 
 ### Small Group Work
 
@@ -22,3 +23,8 @@ Follow along in the following Replit as we livecode the driving function in clas
 - After small group work, we will come back together as a class to work through a solution together, as time allows. Groups may ask questions, share where they got stuck, and/or share out their solutions.
 
 Fork the following Replit to work on in small groups: [Rotate Linked List w/ Helpers Blank](https://replit.com/@adadev/Rotate-Linked-List-Helpers-Blank)
+
+<!--
+Solution:
+* [C19 Small Group Solution](#)
+-->

--- a/03-Binary-Search-Trees/05-Binary-Search-Trees-Activity.md
+++ b/03-Binary-Search-Trees/05-Binary-Search-Trees-Activity.md
@@ -7,9 +7,10 @@ We will go over how to implement a recursive height function for Binary Search T
 ### Class Livecode
 
 Follow along in the following Replit as we livecode the function in class: 
-* [BST Height Ligers Livecode](https://replit.com/@adadev/BST-Height-Ligers-Livecode)
-* [BST Height Tigons Livecode](https://replit.com/@adadev/BST-Height-Tigons-Livecode)
-
+* [BST Height Livecode Start](https://replit.com/@adadev/BST-Height-Livecode-Start)
+<!--
+* [C19 BST Height Livecode Solution](#)
+-->
 
 ### Small Group Work: Kth Smallest Element
 
@@ -22,3 +23,8 @@ For your small group activity,  you will work on implementing 'Kth Smallest Elem
 - After small group work, we will come back together as a class to work through a solution together, as time allows. Groups may ask questions, share where they got stuck, and/or share out their solutions.
 
 Fork the following Replit to work on in small groups: [Kth Smallest Element in BST](https://replit.com/@adadev/BST-Kth-Smallest-Element-Activity)
+
+<!--
+Solution:
+* [C19 Small Group Solution](#)
+-->

--- a/04-graphs/06-graphs-activity.md
+++ b/04-graphs/06-graphs-activity.md
@@ -7,9 +7,10 @@ We will go over how to implement a solution for the Number of Provinces problem.
 ### Class Livecode
 
 Follow along in the following Replit as we livecode the function in class: 
-* [Number of Provinces Ligers Livecode](https://replit.com/@adadev/Number-of-Provinces-Ligers-Livecode)
-* [Number of Provinces Tigons Livecode](https://replit.com/@adadev/Number-of-Provinces-Tigons-Livecode)
-
+* [Number of Provinces Livecode Start](https://replit.com/@adadev/Number-of-Provinces-Livecode-Start)
+<!--
+* [C19 Number of Provinces Livecode Solution](#)
+-->
 
 ### Small Group Work: Graph Variations Activities
 
@@ -25,3 +26,8 @@ Fork one of the following Replits to work on in small groups:
 * [Convert Graph](https://replit.com/@adadev/Convert-Graph-Activity)
 * [DFS with Adjacency Matrix](https://replit.com/@adadev/dfs-with-adjacency-matrix)
 * [Repeat BFS](https://replit.com/@adadev/Repeat-BFS-Activity)
+
+<!--
+Solution:
+* [C19 Small Group Solution](#)
+-->

--- a/05-dijkstras/04-dijkstras-activity.md
+++ b/05-dijkstras/04-dijkstras-activity.md
@@ -9,8 +9,10 @@ Our goal is to practice using Dijkstra's Algorithm to solve shortest/least costl
 As a class we will introduce the interview problem, discuss test cases, why Dijkstra's is a good fit for solving this problem, and possible modifications we may need to make to Dijkstra's to solve this problem.
 
 Follow along in the following Replit as we livecode the function in class: 
-* [Cheapest Flight Ligers Livecode](https://replit.com/@adadev/Cheapest-Flight-Ligers-Livecode)
-* [Cheapest Flight Tigons Livecode](https://replit.com/@adadev/Cheapest-Flight-Tigons-Livecode)
+* [Cheapest Flight Livecode Start](https://replit.com/@adadev/Cheapest-Flight-Livecode-Start)
+<!--
+* [C19 Cheapest Flight Livecode Solution](#)
+-->
 
 ### Breakout Rooms - Minimum Effort Path Pseudocode
 
@@ -18,6 +20,10 @@ In small groups of 3-4 students, pseudocode a solution to the Minimum Effort Pat
 
 **One student** should *fork* the following Repl and share the collaboration link with the rest of the team.  [Minimum Effort Path Activity Repl](https://replit.com/@adadev/Minimum-Effort-Path-Activity)
 
+<!--
+Solution:
+* [C19 Small Group Solution](#)
+-->
 
 #### Exercise
 


### PR DESCRIPTION
The activity replits were mostly all pointing at Tigon/Liger replits, most of which were solved. Where necessary, I forked a non-solved version, then updated the links in Learn. There are commented placeholders for updating with solutions if we would like to do that.

Tracked by: https://app.asana.com/0/1201700438643002/1205462870942887/f