### PR TITLE
Swap Bipartition from PSE to livecode

### DIFF
--- a/04-graphs/06-graphs-activity.md
+++ b/04-graphs/06-graphs-activity.md
@@ -1,15 +1,15 @@
 # Livecode & Activity
 
-## Number of Provinces
+## Bipartition Graph
 
-We will go over how to implement a solution for the Number of Provinces problem.
+We will go over how to implement a solution for the Bipartition Graph problem.
 
 ### Class Livecode
 
 Follow along in the following Replit as we livecode the function in class: 
-* [Number of Provinces Livecode Start](https://replit.com/@adadev/Number-of-Provinces-Livecode-Start)
+* [Bipartition Graph Livecode Start](https://replit.com/@adadev/Bipartition-Graph-Livecode-Start)
 <!--
-* [C19 Number of Provinces Livecode Solution](#)
+* [C19 Bipartition Graph Livecode Solution](#)
 -->
 
 ### Small Group Work: Graph Variations Activities


### PR DESCRIPTION
number of provinces will be the PSE

This change goes along with this PR: https://github.com/Ada-Developers-Academy/cs-fun-interview-practice/pull/9

Replits have been prepared for the livecode:
Start: https://replit.com/@adadev/Bipartition-Graph-Livecode-Start
Instructor Solution: https://replit.com/@adadev/Bipartition-Graph-Instructor-Solution
Workspace: https://replit.com/@adadev/Bipartition-Graph-Instructor-Solution-Workspace

The workspace was used while I was trying to find a counterexample to prove that the color-based clean-up step (popping from the color data) was required even for a 2-color scenario. I could not manually construct an example that failed. Solution? Generate all possible permutations of all possible graphs. Fortunately, a counterexample was found for a relative simple 6-node graph. It also contains a bit about a nonsolution that might be something that comes to mind, and sets up a little for how that can lead to the coloring solution.

We're _really_ only planning to work through the traversal-based solution, but the color-based solution can be shared along with the traversal, or we could hold an extra optional session (since getting graph coloring into Learn this time around seems like a stretch).